### PR TITLE
Add script to set extension to types from typechain

### DIFF
--- a/addExtensionJs.js
+++ b/addExtensionJs.js
@@ -1,0 +1,43 @@
+import fs from "fs";
+import path from "path";
+
+// Define the directory with the generated files
+const directoryPath = path.join(process.cwd(), "src/typechain");
+
+function processDirectory(dirPath) {
+  fs.readdir(dirPath, { withFileTypes: true }, (err, entries) => {
+    if (err) {
+      return console.log("Unable to scan directory: " + err);
+    }
+
+    entries.forEach((entry) => {
+      const entryPath = path.join(dirPath, entry.name);
+      if (entry.isDirectory()) {
+        processDirectory(entryPath);
+      } else if (entry.isFile()) {
+        processFile(entryPath);
+      }
+    });
+  });
+}
+
+function processFile(filePath) {
+  fs.readFile(filePath, "utf8", (err, data) => {
+    if (err) {
+      return console.log("Unable to read file: " + err);
+    }
+
+    const result = data
+      .replace(
+        /from ['"](.*?)(factories|contracts_v0\.5|contracts_v0\.4)['"]/g,
+        'from "$1$2/index.js"'
+      )
+      .replace(/from ['"](\.\/.*?|..\/.*?)(?<!\.js)['"]/g, 'from "$1.js"');
+
+    fs.writeFile(filePath, result, "utf8", (err) => {
+      if (err) return console.log("Error writing file: " + err);
+    });
+  });
+}
+
+processDirectory(directoryPath);

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "tag-and-publish": "npm version patch && git push --follow-tags",
     "clean": "rimraf dist",
-    "build": "npm run clean && npm run truffle:compile:v0.4 && npm run truffle:compile:v0.5 && npm run typechain && tsc",
+    "build": "npm run clean && npm run truffle:compile:v0.4 && npm run truffle:compile:v0.5 && npm run typechain && node addExtensionJs.js && tsc",
     "lint": "eslint . --ext .ts",
     "format": "prettier --write \"src/**/*.ts\"",
     "typechain": "typechain --target ethers-v6 --out-dir ./src/typechain './truffle/contracts_build/contracts*/*.json'",

--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
   "scripts": {
     "tag-and-publish": "npm version patch && git push --follow-tags",
     "clean": "rimraf dist",
-    "build": "npm run clean && npm run truffle:compile:v0.4 && npm run truffle:compile:v0.5 && npm run typechain && node addExtensionJs.js && tsc",
+    "build": "npm run clean && npm run truffle:compile:v0.4 && npm run truffle:compile:v0.5 && npm run typechain && tsc",
     "lint": "eslint . --ext .ts",
     "format": "prettier --write \"src/**/*.ts\"",
-    "typechain": "typechain --target ethers-v6 --out-dir ./src/typechain './truffle/contracts_build/contracts*/*.json'",
+    "typechain": "typechain --target ethers-v6 --out-dir ./src/typechain './truffle/contracts_build/contracts*/*.json' && node addExtensionJs.js",
     "test": "mocha --config .mocharc.yml test/**/*.test.ts",
     "truffle:compile:v0.4": "truffle compile --config ./truffle/truffle-config-v0.4.cjs",
     "truffle:compile:v0.5": "truffle compile --config ./truffle/truffle-config-v0.5.cjs",

--- a/src/repository/repository.ts
+++ b/src/repository/repository.ts
@@ -204,12 +204,23 @@ export class DappnodeRepository extends ApmRepository {
     const content = await this.unpackCarReader(carReader, root);
     for await (const chunk of content) chunks.push(chunk);
 
-    const buffer = Buffer.concat(chunks);
+    // Concatenate the chunks into a single Uint8Array
+    let totalLength = 0;
+    chunks.forEach((chunk) => (totalLength += chunk.length));
+    const buffer = new Uint8Array(totalLength);
+    let offset = 0;
+    chunks.forEach((chunk) => {
+      buffer.set(chunk, offset);
+      offset += chunk.length;
+    });
+
     if (maxLength && buffer.length >= maxLength)
       throw Error(`Maximum size ${maxLength} bytes exceeded`);
 
-    // TODO: the data encoding may be different from utf8, depending on the file type, we should detect it automatically. Consider using carHeader
-    return buffer.toString("utf8");
+    // Convert the Uint8Array to a string
+    // TODO: This assumes the data is UTF-8 encoded. If it's not, you will need a more complex conversion. Research which encoding is used by IPFS.
+    const decoder = new TextDecoder("utf-8");
+    return decoder.decode(buffer);
   }
 
   /**

--- a/src/repository/repository.ts
+++ b/src/repository/repository.ts
@@ -6,11 +6,11 @@ import {
   FileFormat,
   NodeArch,
   DistributedFile,
+  IPFSEntry,
 } from "./types.js";
 import { CID, IPFSHTTPClient, create } from "ipfs-http-client";
 import { CarReader } from "@ipld/car";
 import { recursive as exporter } from "ipfs-unixfs-exporter";
-import { IPFSEntry } from "ipfs-core-types/src/root.js";
 import { Version } from "multiformats";
 import path from "path";
 import fs from "fs";

--- a/src/repository/types.ts
+++ b/src/repository/types.ts
@@ -4,7 +4,7 @@ import {
   Manifest,
   PrometheusTarget,
 } from "@dappnode/types";
-import { IPFSEntry } from "ipfs-core-types/src/root.js";
+import { CID } from "ipfs-http-client";
 
 /**
  * IPFS
@@ -24,7 +24,18 @@ export type NodeArch =
   | "x32"
   | "x64";
 
-export type IPFSEntryName = Pick<IPFSEntry, "name">;
+/**
+ * TODO: the interface IPFSEntry is not properly exported by library ipfs-core-types. If importing it directly then the compiler throws an error. Version: 0.14.0
+ */
+export interface IPFSEntry {
+  readonly type: "dir" | "file";
+  readonly cid: CID;
+  readonly name: string;
+  readonly path: string;
+  mode?: number;
+  mtime?: any;
+  size: number;
+}
 
 /**
  * PKG release assets

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "forceConsistentCasingInFileNames": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "moduleResolution": "node",
+    "moduleResolution": "nodenext",
     "baseUrl": ".",
     "paths": {
       "*": ["node_modules/*", "src/*"]


### PR DESCRIPTION
Add script to set extension to types from typechain. Remove import from ipfs-core-types as long as its resulting in compiler erorr.

Use Uint8Array in function `writeFileToMemory` so its browser-compatible