### PR TITLE
Dont use enum

### DIFF
--- a/src/registry/registry.ts
+++ b/src/registry/registry.ts
@@ -1,10 +1,6 @@
 import { ethers } from "ethers";
 import { APMRegistry, APMRegistry__factory } from "../typechain/index.js";
-import {
-  DNPRegistryEntry,
-  PublicRegistryEntry,
-  RegistryType,
-} from "./types.js";
+import { DNPRegistryEntry, PublicRegistryEntry, Registry } from "./types.js";
 import { request, gql } from "graphql-request";
 import {
   registryDnpAddress,
@@ -20,7 +16,7 @@ import {
  */
 export class DappNodeRegistry {
   private contractAddress: string;
-  private registry: RegistryType;
+  private registry: Registry;
   private graphEndpoint: string;
   private registryContract: APMRegistry;
 
@@ -29,9 +25,9 @@ export class DappNodeRegistry {
    * @param ethProvider - The ethers provider to interact with the Ethereum network.
    * @param registry - The type of the registry (DNP or Public).
    */
-  constructor(ethProvider: ethers.Provider, registry: RegistryType) {
+  constructor(ethProvider: ethers.Provider, registry: Registry) {
     this.registry = registry;
-    if (registry === RegistryType.dnp) {
+    if (registry === "dnp") {
       this.contractAddress = registryDnpAddress;
       this.graphEndpoint = dnpRegistryGraphEndpoint;
     } else {
@@ -49,8 +45,8 @@ export class DappNodeRegistry {
    * Fetches the packages for the given registry using graphQL.
    * @returns - A promise that resolves to an array of registry entries.
    */
-  public async queryGraphNewRepos<T extends RegistryType>(): Promise<
-    T extends RegistryType.dnp ? DNPRegistryEntry : PublicRegistryEntry
+  public async queryGraphNewRepos<T extends Registry>(): Promise<
+    T extends "dnp" ? DNPRegistryEntry : PublicRegistryEntry
   > {
     const query = this.constructGraphQLQuery();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -62,7 +58,7 @@ export class DappNodeRegistry {
    * @returns - The GraphQL query string.
    */
   private constructGraphQLQuery(): string {
-    return this.registry === RegistryType.dnp
+    return this.registry === "dnp"
       ? gql`
           query {
             newRepos {

--- a/src/registry/types.ts
+++ b/src/registry/types.ts
@@ -1,7 +1,4 @@
-export const enum RegistryType {
-  dnp = "dnp.dappnode.eth",
-  public = "public.dappnode.eth",
-}
+export type Registry = "dnp" | "public";
 
 interface RegistryEntry {
   id: string;

--- a/test/registry/registry.test.ts
+++ b/test/registry/registry.test.ts
@@ -4,13 +4,13 @@ import {
   DNPRegistryEntry,
   PublicRegistryEntry,
   DappNodeRegistry,
-  RegistryType,
+  Registry,
 } from "../../src/registry/index.js";
 
 describe("Dappnode Registry", function () {
   this.timeout(100000);
 
-  it(`should get ${RegistryType.dnp} newRepos`, async () => {
+  it(`should get dnp newRepos`, async () => {
     const expectedResult: DNPRegistryEntry[] = [
       {
         id: "0x014a26511e1a8896e6b60002f82de526ee2e3452e5a170b74bc97c01fc4864f9f8000000",
@@ -717,12 +717,12 @@ describe("Dappnode Registry", function () {
       "mainnet",
       process.env.INFURA_MAINNET_KEY
     );
-    const contract = new DappNodeRegistry(ethProvider, RegistryType.dnp);
-    const result = await contract.queryGraphNewRepos<RegistryType.dnp>();
+    const contract = new DappNodeRegistry(ethProvider, "dnp");
+    const result = await contract.queryGraphNewRepos<"dnp">();
     expect(result).to.have.deep.members(expectedResult);
   });
 
-  it(`should get ${RegistryType.public} newRepos`, async () => {
+  it(`should get public newRepos`, async () => {
     const expectedResult: PublicRegistryEntry[] = [
       {
         id: "0x0060cb7c75f6bf1709541b92a8c7482f2c2ba62e62dfed90bcbdfb763465c5277b000000",
@@ -1247,9 +1247,9 @@ describe("Dappnode Registry", function () {
       "mainnet",
       process.env.INFURA_MAINNET_KEY
     );
-    const contract = new DappNodeRegistry(ethProvider, RegistryType.public);
+    const contract = new DappNodeRegistry(ethProvider, "public");
 
-    const result = await contract.queryGraphNewRepos<RegistryType.public>();
+    const result = await contract.queryGraphNewRepos<"public">();
     expect(result).to.have.deep.members(expectedResult);
   });
 });


### PR DESCRIPTION
Dont use enum in favor of Type as long as:
> Cannot access ambient const enums when 'isolatedModules' is enabled