### PR TITLE
export ApmRepository

### DIFF
--- a/src/repository/index.ts
+++ b/src/repository/index.ts
@@ -1,3 +1,4 @@
 export * from "./params.js";
 export * from "./repository.js";
 export * from "./types.js";
+export * from "./apmRepository.js";


### PR DESCRIPTION
Export ApmRepository.ts so that _ApmRepository_ class can be used in dappnodeSDK