### PR TITLE
add getRegistryContract + make getRepoContract public

### DIFF
--- a/src/repository/apmRepository.ts
+++ b/src/repository/apmRepository.ts
@@ -24,7 +24,7 @@ export class ApmRepository {
    * @param dnpName - The name of the DNP to resolve.
    * @returns - A promise that resolves to the Repo instance.
    */
-  private async getRepoContract(dnpName: string): Promise<Repo> {
+  public async getRepoContract(dnpName: string): Promise<Repo> {
     const contractAddress = await this.ethProvider.resolveName(
       this.ensureValidDnpName(dnpName)
     );
@@ -59,6 +59,22 @@ export class ApmRepository {
       contractAddress: res[1],
       contentURI: res[2],
     });
+  }
+
+   /**
+   * Get the registry contract for an ENS domain and the registry ABI.
+   * It will slice the first subdomain and query the rest as the registry domain.
+    * ENS domain:      admin.dnp.dappnode.eth
+    * Registry domain:       dnp.dappnode.eth
+   * @param ensName - The ENS domain name, e.g., "admin.dnp.dappnode.eth".
+   * @param registryAbi - The ABI of the registry contract in JSON format.
+   * @returns A contract instance of the registry for the specified ENS domain, or null if the registry address is not resolved.
+   */
+  public async getRegistryContract(ensName: string, registryAbi: string): Promise<ethers.Contract | null> {
+    const repoId = ensName.split(".").slice(1).join(".");
+    const registryAddress = await this.ethProvider.resolveName(repoId);
+    if (!registryAddress) return null;
+    return new ethers.Contract(registryAddress, registryAbi, this.ethProvider);
   }
 
   /**


### PR DESCRIPTION
Two changes to the apmRepository class:

- changed **getRepoContract** function from _private_ to _public_
- Added a new function **getRegistryContract** that is used in the [dappnodeSDK](https://github.com/dappnode/DAppNodeSDK/blob/86bbdb1735cb0ac503e530da3e430db0c499b995/src/utils/Apm.ts#L115) with a tweak: Added the _registryAbi_ parameter, since it is necessary for the creation of the return contract. In the current SDK implementation, it is not necessary to pass it as a parameter because it is imported in the [file](https://github.com/dappnode/DAppNodeSDK/blob/86bbdb1735cb0ac503e530da3e430db0c499b995/src/utils/Apm.ts#L4) first, unsure if it should be the same in this toolkit class. Passing it as a parameter may provide more flexibility to the toolkit user.
